### PR TITLE
Fix a potential random generated related nan issue caused by 0/0

### DIFF
--- a/torchvahadane/dict_learning.py
+++ b/torchvahadane/dict_learning.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
+from torchvahadane.eps import get_eps
 # min_{D in C} = (1/n) sum_{i=1}^n (1/2)||x_i-Dalpha_i||_2^2 + lambda1||alpha_i||_1 + lambda1_2||alpha_i||_2^2
 
 def lasso_loss(X, Z, weight, alpha=1.0):
@@ -97,10 +97,17 @@ def update_dict(dictionary, X, Z, random_seed=None, positive=True,
         # Re-scale k'th atom
         atom_norm = dictionary[:, k].norm()
         if atom_norm < eps:
+            # note that the random generated number can be all negative
+            # and the clamp will get you a zero vector with zero norm --> 0/0 = nan
             dictionary[:, k].normal_()
+            dictionary[:, k] = dictionary[:, k].abs()
+            # might be
             if positive:
+                # if all negative this line will create a zero vector
                 dictionary[:, k].clamp_(0, None)
-            dictionary[:, k] /= dictionary[:, k].norm()
+            # another layer of protection
+            column_norm = dictionary[:, k].norm() + get_eps(dictionary)
+            dictionary[:, k] /= column_norm
             # Set corresponding coefs to 0
             Z[:, k].zero_()  # TODO: is this necessary?
         else:

--- a/torchvahadane/eps.py
+++ b/torchvahadane/eps.py
@@ -1,0 +1,10 @@
+import torch
+
+_eps_val = torch.finfo(torch.float32).eps
+
+
+def get_eps(img: torch.Tensor = None):
+    eps = torch.tensor(_eps_val)
+    if img is not None:
+        eps = eps.to(img.device)
+    return eps


### PR DESCRIPTION
In the update_dict method in https://github.com/cwlkr/torchvahadane/blob/main/torchvahadane/dict_learning.py#L100, when the atomic norm is too small, the corresponding atom is re-initialized with tensor.normal_.
However, if all numbers drawn are negative, the following in-place clamp will yield a zero vector, and in the in-place normalization
of `dictionary[:, k] /= dictionary[:, k].norm()` a nan vector will be generated and this will invalidate the whole computation procedure.

Herein two layers of protection is added:
(1) make the re-initialized atom non-negative by adding abs()
(2) add a small eps `torch.finfo(torch.float32).eps` to the norm so the denominator (norm) will always be non-zero.